### PR TITLE
Modularized Account Menu, Improved Secure Pages & Applied Linting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 /libpeerconnection.log
 npm-debug.log*
 testem.log
+
+# Ignore Sublime files
+*.sublime*

--- a/addon/components/account-menu.js
+++ b/addon/components/account-menu.js
@@ -1,13 +1,16 @@
 import Ember from 'ember';
 import layout from '../templates/components/account-menu';
 
-export default Ember.Component.extend({
-  layout,
+const { Component, inject, computed, get } = Ember;
+
+export default Component.extend({
+  'account-config': inject.service(),
   classNames: ['menu-section'],
-  active:    'active account-btn',
+  active: 'active account-btn',
   notActive: 'account-btn',
-  'account-config': Ember.inject.service(),
-  links: Ember.computed('account-config.links', function() {
-    return this.get('account-config.links');
+  layout,
+
+  links: computed('account-config.links', function() {
+    return get(this, 'account-config.links');
   })
 });

--- a/addon/components/account-menu.js
+++ b/addon/components/account-menu.js
@@ -1,10 +1,15 @@
 import Ember from 'ember';
 import layout from '../templates/components/account-menu';
 
-const { Component, inject, computed, get } = Ember;
+const {
+  Component,
+  inject: { service },
+  computed,
+  get
+} = Ember;
 
 export default Component.extend({
-  'account-config': inject.service(),
+  'account-config': service(),
   classNames: ['menu-section'],
   active: 'active account-btn',
   notActive: 'account-btn',

--- a/addon/components/delete-user.js
+++ b/addon/components/delete-user.js
@@ -76,7 +76,6 @@ export default Ember.Component.extend({
             });
 
           }, (error) => {
-            Ember.Logger.log("ERROR 1");
             Ember.Logger.log(error);
             scope.get('notify').alert(scope.get('account-config').messages['incorrectPassword']);
             reject();

--- a/addon/components/delete-user.js
+++ b/addon/components/delete-user.js
@@ -5,18 +5,18 @@ import firebase from 'firebase';
 
 const {
   Component,
-  inject,
+  inject: { service },
   get,
   set,
   Logger
 } = Ember;
 
 export default Component.extend({
-  firebaseApp: inject.service(),
-  session: inject.service(),
-  store: inject.service(),
-  notify: inject.service(),
-  'account-config': inject.service(),
+  firebaseApp: service(),
+  session: service(),
+  store: service(),
+  notify: service(),
+  'account-config': service(),
   hasError: false,
   layout,
 

--- a/addon/components/delete-user.js
+++ b/addon/components/delete-user.js
@@ -8,7 +8,7 @@ const {
   inject: { service },
   get,
   set,
-  Logger
+  Logger: { log }
 } = Ember;
 
 export default Component.extend({
@@ -65,11 +65,11 @@ export default Component.extend({
               get(scope, 'notify').success(config.messages.successfulDeleteAccount);
             }
           } catch(error) {
-            Logger.log(error);
+            log(error);
             get(scope, 'notify').alert(config.messages.unsuccessfulDeleteAccount);
           }
         } catch(error) {
-          Logger.log(error);
+          log(error);
           get(scope, 'notify').alert(config.messages.incorrectPassword);
         }
       }

--- a/addon/components/delete-user.js
+++ b/addon/components/delete-user.js
@@ -3,91 +3,76 @@ import Changeset from 'ember-changeset';
 import layout from '../templates/components/delete-user';
 import firebase from 'firebase';
 
-export default Ember.Component.extend({
-  layout,
-  className: ['delete-user-component'],
-  firebaseApp: Ember.inject.service(),
-  session: Ember.inject.service(),
-  store: Ember.inject.service(),
-  notify: Ember.inject.service(),
-  'account-config': Ember.inject.service(),
+const {
+  Component,
+  inject,
+  get,
+  set,
+  Logger
+} = Ember;
+
+export default Component.extend({
+  firebaseApp: inject.service(),
+  session: inject.service(),
+  store: inject.service(),
+  notify: inject.service(),
+  'account-config': inject.service(),
   hasError: false,
+  layout,
 
-  actions: {
-    deleteUser(form) {
-      const scope = this,
-        config = scope.get('account-config'),
-        user = this.get('firebaseApp').auth().currentUser;
-
-      return new Ember.RSVP.Promise(function(resolve, reject) {
-        if(scope.get('session.isAuthenticated')) {
-          const currentUser = scope.get('firebaseApp').auth().currentUser;
-
-          // Get credentials for reauthentication via the user email and the entered password
-          let credential = firebase.auth.EmailAuthProvider.credential(currentUser.email, form.get('currentPassword'));
-
-          currentUser.reauthenticate(credential).then(() => {
-
-            scope.get('store').findRecord('user', currentUser.uid).then((record) => {
-              if(config.hardDelete) {
-                // if hard deleting, destroy the user
-                rec.destroyRecord();
-
-                user.delete().then(() => {
-                  scope.get('session').close().then(() => {
-                    scope.get('router').transitionTo('index');
-                    scope.get('notify').success(config.messages['successfulDeleteAccount']);
-                    resolve();
-                  }, reject);
-                }, (error) => {
-                  Ember.Logger.log(error);
-                  scope.get('notify').alert(config.messages['unsuccessfulDeleteAccount']);
-                  reject();
-                });
-              }
-              else {
-                // if not hard deleting the user, flag the account as deleted
-                if(config.deleted)
-                  record.set(config.deleted, true);
-
-                record.save().then(() => {
-                  user.delete().then(() => {
-                    scope.get('session').close().then(() => {
-                      scope.get('router').transitionTo('index');
-                      scope.get('notify').success(config.messages['successfulDeleteAccount']);
-                      resolve();
-                    }, reject);
-                  }, (error) => {
-                    Ember.Logger.log(error);
-                    scope.get('notify').alert(config.messages['unsuccessfulDeleteAccount']);
-                    reject();
-                  });
-
-                  resolve();
-                }, (error) => {
-                  scope.get('notify').alert(config.messages['successfulDeleteAccount']);
-                  reject();
-                });
-              }
-            }, (error) => {
-              Ember.Logger.log(error);
-              scope.get('notify').alert(config.messages['unsuccessfulDeleteAccount']);
-              reject();
-            });
-
-          }, (error) => {
-            Ember.Logger.log(error);
-            scope.get('notify').alert(scope.get('account-config').messages['incorrectPassword']);
-            reject();
-          });
-        }
-
-        reject();
-      });
-    }
-  },
   init() {
     this._super(...arguments);
-    this.delete_form = new Changeset({currentPassword: ''});
+    this.deleteForm = new Changeset({ currentPassword: '' });
+    this.className = ['delete-user-component'];
+  },
+
+  actions: {
+    async deleteUser(form) {
+      let scope = this;
+      let config = get(scope, 'account-config');
+
+      if (get(scope, 'session.isAuthenticated')) {
+        let currentUser = get(scope, 'firebaseApp').auth().currentUser; // eslint-disable-line ember-suave/prefer-destructuring
+
+        // Get credentials for reauthentication via the user email and the entered password
+        let credential = firebase.auth.EmailAuthProvider.credential(currentUser.email, get(form, 'currentPassword'));
+
+        // try to reauthenticate, and catch any errors that come up
+        try {
+          await currentUser.reauthenticate(credential);
+
+          try {
+            let userRecord = await get(scope, 'store').findRecord('user', currentUser.uid);
+
+            if (config.hardDelete) {
+              // if hard deleting, destroy the user
+              userRecord.destroyRecord();
+
+              await currentUser.delete();
+              await get(scope, 'session').close();
+              get(scope, 'router').transitionTo('index');
+              get(scope, 'notify').success(config.messages.successfulDeleteAccount);
+            } else {
+              // if not hard deleting the user, flag the account as deleted
+              if (config.deleted) {
+                set(userRecord, config.deleted, true);
+                await userRecord.save();
+              }
+
+              await currentUser.delete();
+              await get(scope, 'session').close();
+              get(scope, 'router').transitionTo('index');
+              get(scope, 'notify').success(config.messages.successfulDeleteAccount);
+            }
+          } catch(error) {
+            Logger.log(error);
+            get(scope, 'notify').alert(config.messages.unsuccessfulDeleteAccount);
+          }
+        } catch(error) {
+          Logger.log(error);
+          get(scope, 'notify').alert(config.messages.incorrectPassword);
+        }
+      }
+    }
   }
 });

--- a/addon/components/delete-user.js
+++ b/addon/components/delete-user.js
@@ -1,5 +1,7 @@
 import Ember from 'ember';
+import Changeset from 'ember-changeset';
 import layout from '../templates/components/delete-user';
+import firebase from 'firebase';
 
 export default Ember.Component.extend({
   layout,
@@ -9,50 +11,84 @@ export default Ember.Component.extend({
   store: Ember.inject.service(),
   notify: Ember.inject.service(),
   'account-config': Ember.inject.service(),
-  reauthenticate: Ember.inject.service(),
   hasError: false,
+
   actions: {
-    deleteUser(form){
+    deleteUser(form) {
       const scope = this,
-            config = scope.get('account-config'),
-            user = this.get('firebaseApp').auth().currentUser;
+        config = scope.get('account-config'),
+        user = this.get('firebaseApp').auth().currentUser;
+
       return new Ember.RSVP.Promise(function(resolve, reject) {
-        if(user && user.email === form.email){
-          if(config.hardDelete){
-            scope.get('store').findRecord("user", user.uid).then((rec) => {
-              rec.destroyRecord();
-              scope.get('notify').success(config.messages['successfulDeleteAccount']);
-            });
-          }
-          user.delete().then(() => {
-            scope.get('session').close().then(() => {
-              scope.get('router').transitionTo('index');
-              resolve();
-            }, reject);
-          }, (error) => {
-            if(error.code === 'auth/requires-recent-login') {
+        if(scope.get('session.isAuthenticated')) {
+          const currentUser = scope.get('firebaseApp').auth().currentUser;
+
+          // Get credentials for reauthentication via the user email and the entered password
+          let credential = firebase.auth.EmailAuthProvider.credential(currentUser.email, form.get('currentPassword'));
+
+          currentUser.reauthenticate(credential).then(() => {
+
+            scope.get('store').findRecord('user', currentUser.uid).then((record) => {
+              if(config.hardDelete) {
+                // if hard deleting, destroy the user
+                rec.destroyRecord();
+
+                user.delete().then(() => {
+                  scope.get('session').close().then(() => {
+                    scope.get('router').transitionTo('index');
+                    scope.get('notify').success(config.messages['successfulDeleteAccount']);
+                    resolve();
+                  }, reject);
+                }, (error) => {
+                  Ember.Logger.log(error);
+                  scope.get('notify').alert(config.messages['unsuccessfulDeleteAccount']);
+                  reject();
+                });
+              }
+              else {
+                // if not hard deleting the user, flag the account as deleted
+                if(config.deleted)
+                  record.set(config.deleted, true);
+
+                record.save().then(() => {
+                  user.delete().then(() => {
+                    scope.get('session').close().then(() => {
+                      scope.get('router').transitionTo('index');
+                      scope.get('notify').success(config.messages['successfulDeleteAccount']);
+                      resolve();
+                    }, reject);
+                  }, (error) => {
+                    Ember.Logger.log(error);
+                    scope.get('notify').alert(config.messages['unsuccessfulDeleteAccount']);
+                    reject();
+                  });
+
+                  resolve();
+                }, (error) => {
+                  scope.get('notify').alert(config.messages['successfulDeleteAccount']);
+                  reject();
+                });
+              }
+            }, (error) => {
+              Ember.Logger.log(error);
               scope.get('notify').alert(config.messages['unsuccessfulDeleteAccount']);
-              scope.get('reauthenticate').set('shouldReauthenticate', true);
-            }
+              reject();
+            });
+
+          }, (error) => {
+            Ember.Logger.log("ERROR 1");
+            Ember.Logger.log(error);
+            scope.get('notify').alert(scope.get('account-config').messages['incorrectPassword']);
             reject();
           });
         }
-        else {
-          if(!scope.get("hasError")){
-            scope.get('notify').alert(config.messages['unsuccessfulDeleteAccount']);
-            Ember.$('.ef-account-form-input').append('<div class="form-field--errors">Incorrect email. Please re-enter your e-mail.</div>');
-            scope.set("hasError", true);
-          }
-          reject();
-        }
+
+        reject();
       });
     }
   },
-  shouldReauthenticate: Ember.computed('reauthenticate.shouldReauthenticate', function() {
-    return this.get('reauthenticate.shouldReauthenticate');
-  }),
   init() {
     this._super(...arguments);
-    this.delete_form = {email: ''};
+    this.delete_form = new Changeset({currentPassword: ''});
   }
 });

--- a/addon/components/re-authenticate.js
+++ b/addon/components/re-authenticate.js
@@ -10,7 +10,7 @@ const {
   get,
   set,
   inject: { service },
-  Logger
+  Logger: { log }
 } = Ember;
 
 export default Component.extend({
@@ -45,11 +45,11 @@ export default Component.extend({
           // reauthenticated the user for the next operation
           set(get(scope, 'reauthenticate'), 'shouldReauthenticate', false);
         } catch(error) {
-          Logger.log(error);
+          log(error);
           get(scope, 'notify').alert(config.messages.unsuccessfulLogin);
         }
       } catch(error) {
-        Logger.log(error);
+        log(error);
       }
     }
   }

--- a/addon/components/re-authenticate.js
+++ b/addon/components/re-authenticate.js
@@ -9,42 +9,48 @@ const {
   Component,
   get,
   set,
-  inject: { service }
+  inject: { service },
+  Logger
 } = Ember;
 
 export default Component.extend({
-  layout,
-  actions: {
-    reauthenticate(form) {
-      const scope = this;
-      return new Ember.RSVP.Promise(function(resolve, reject) {
-        form.validate().then(() => {
-          if(form.get('isValid')){
-            // Credential should work regardless of which account provider they decide to sign in with
-            const credential = firebase.auth.EmailAuthProvider.credential(get(form, 'email'), get(form, 'password'));
-
-            get(scope, 'firebaseApp').auth().currentUser.reauthenticate(credential).then(() => {
-              // reauthenticated the user for the next operation
-              set(get(scope, 'reauthenticate'), 'shouldReauthenticate', false);
-              resolve();
-            }, (error) => {
-              console.log(error);
-              reject();
-            });
-          }else{
-            reject();
-          }
-        }, () => {
-          reject();
-        });
-      });
-    }
-  },
+  notify: service(),
   session: service(),
   firebaseApp: service(),
   reauthenticate: service(),
+  layout,
+
   init() {
     this._super(...arguments);
     this.creds = new Changeset({ email: '', password: '' }, lookupValidator(ReauthenticateValidations), ReauthenticateValidations);
+  },
+
+  actions: {
+    async reauthenticate(form) {
+      let scope = this;
+      let config = get(scope, 'account-config');
+
+      try {
+        await form.validate();
+
+        if (!get(form, 'isValid')) {
+          return;
+        }
+
+        // Credential should work regardless of which account provider they decide to sign in with
+        let credential = firebase.auth.EmailAuthProvider.credential(get(form, 'email'), get(form, 'password'));
+
+        try {
+          await get(scope, 'firebaseApp').auth().currentUser.reauthenticate(credential);
+          // reauthenticated the user for the next operation
+          set(get(scope, 'reauthenticate'), 'shouldReauthenticate', false);
+        } catch(error) {
+          Logger.log(error);
+          get(scope, 'notify').alert(config.messages.unsuccessfulLogin);
+        }
+      } catch(error) {
+        Logger.log(error);
+      }
+    }
   }
 });

--- a/addon/components/update-email.js
+++ b/addon/components/update-email.js
@@ -59,5 +59,7 @@ export default Ember.Component.extend({
   init() {
     this._super(...arguments);
     this.email = new Changeset({email: '', emailConfirmation: ''}, lookupValidator(EmailValidations), EmailValidations);
+    this.currentEmail = this.get('firebaseApp').auth().currentUser.email;
+    this.currentEmailPrompt = this.get('account-config').messages['currentEmailPrompt'];
   }
 });

--- a/addon/components/update-email.js
+++ b/addon/components/update-email.js
@@ -6,7 +6,7 @@ import lookupValidator from 'ember-changeset-validations';
 import firebase from 'firebase';
 
 const {
-  inject,
+  inject: { service },
   Component,
   Logger,
   get,
@@ -14,11 +14,11 @@ const {
 } = Ember;
 
 export default Component.extend({
-  firebaseApp: inject.service(),
-  session: inject.service(),
-  notify: inject.service(),
-  'account-config': inject.service(),
-  store: inject.service(),
+  firebaseApp: service(),
+  session: service(),
+  notify: service(),
+  'account-config': service(),
+  store: service(),
   layout,
   EmailValidations,
 

--- a/addon/components/update-email.js
+++ b/addon/components/update-email.js
@@ -8,7 +8,7 @@ import firebase from 'firebase';
 const {
   inject: { service },
   Component,
-  Logger,
+  Logger: { log },
   get,
   set
 } = Ember;
@@ -55,11 +55,11 @@ export default Component.extend({
             }
 
           } catch(error) {
-            Logger.log(error);
+            log(error);
             get(scope, 'notify').alert(config.messages.unsuccessfulUpdateEmail);
           }
         } catch(error) {
-          Logger.log(error);
+          log(error);
           get(scope, 'notify').alert(config.messages.incorrectPassword);
         }
       }

--- a/addon/components/update-email.js
+++ b/addon/components/update-email.js
@@ -5,70 +5,64 @@ import Changeset from 'ember-changeset';
 import lookupValidator from 'ember-changeset-validations';
 import firebase from 'firebase';
 
-export default Ember.Component.extend({
+const {
+  inject,
+  Component,
+  Logger,
+  get,
+  set
+} = Ember;
+
+export default Component.extend({
+  firebaseApp: inject.service(),
+  session: inject.service(),
+  notify: inject.service(),
+  'account-config': inject.service(),
+  store: inject.service(),
   layout,
-  classNames: ['update-email-component'],
-  firebaseApp: Ember.inject.service(),
-  session: Ember.inject.service(),
-  notify: Ember.inject.service(),
-  'account-config': Ember.inject.service(),
-  store: Ember.inject.service(),
-  actions: {
-    updateEmail(form) {
-      const scope = this;
-      return new Ember.RSVP.Promise(function(resolve, reject) {
-        if (scope.get('session.isAuthenticated') && scope.get('email').get('isValid')) {
-          const currentUser = scope.get('firebaseApp').auth().currentUser;
-
-          // Get credentials for reauthentication via the user email and the entered password
-          const credential = firebase.auth.EmailAuthProvider.credential(currentUser.email, form.get('currentPassword'));
-
-          currentUser.reauthenticate(credential).then(() => {
-
-            currentUser.updateEmail(form.get('email')).then(() => {
-              if (scope.get('account-config').email) {
-                scope.get('store').findRecord('user', currentUser.uid).then((data) => {
-                  data.set(scope.get('account-config').email, form.get('email'));
-
-                  data.save().then(() => {
-                    scope.get('notify').success(scope.get('account-config').messages['successfulUpdateEmail']);
-                    resolve();
-                  }, (error) => {
-                    scope.get('notify').alert(scope.get('account-config').messages['unsuccessfulUpdateEmail']);
-                    reject();
-                  });
-
-                }, (error) => {
-                  scope.get('notify').alert(scope.get('account-config').messages['unsuccessfulUpdateEmail']);
-                  reject();
-                });
-              }
-              else {
-                scope.get('notify').success(scope.get('account-config').messages['successfulUpdateEmail']);
-                resolve();
-              }
-            }, (error) => {
-              Ember.Logger.log(error);
-              scope.get('notify').alert(scope.get('account-config').messages['unsuccessfulUpdateEmail']);
-              reject();
-            });
-
-          }, (error) => {
-            Ember.Logger.log(error);
-            scope.get('notify').alert(scope.get('account-config').messages['incorrectPassword']);
-            reject();
-          });
-        }
-
-        reject();
-      });
-    }
-  },
   EmailValidations,
+
   init() {
     this._super(...arguments);
-    this.email = new Changeset({email: '', emailConfirmation: '', currentPassword: ''}, lookupValidator(EmailValidations), EmailValidations);
-    this.currentEmail = this.get('firebaseApp').auth().currentUser.email;
-    this.currentEmailPrompt = this.get('account-config').messages['currentEmailPrompt'];
+    this.email = new Changeset({ email: '', emailConfirmation: '', currentPassword: '' }, lookupValidator(EmailValidations), EmailValidations);
+    this.currentEmail = get(this, 'firebaseApp').auth().currentUser.email;
+    this.currentEmailPrompt = get(this, 'account-config').messages.currentEmailPrompt;
+    this.classNames = ['update-email-component'];
+  },
+
+  actions: {
+    async updateEmail(form) {
+      let scope = this;
+      let config = get(scope, 'account-config');
+
+      if (get(scope, 'session.isAuthenticated') && get(get(scope, 'email'), 'isValid')) {
+        let currentUser = get(scope, 'firebaseApp').auth().currentUser; // eslint-disable-line ember-suave/prefer-destructuring
+
+        // Get credentials for reauthentication via the user email and the entered password
+        let credential = firebase.auth.EmailAuthProvider.credential(currentUser.email, get(form, 'currentPassword'));
+
+        try {
+          await currentUser.reauthenticate(credential);
+
+          try {
+            await currentUser.updateEmail(get(form, 'email'));
+
+            if (config.email) {
+              let userRecord = await get(scope, 'store').findRecord('user', currentUser.uid);
+              set(userRecord, config.email, get(form, 'email'));
+              await userRecord.save();
+              get(scope, 'notify').success(config.messages.successfulUpdateEmail);
+            }
+
+          } catch(error) {
+            Logger.log(error);
+            get(scope, 'notify').alert(config.messages.unsuccessfulUpdateEmail);
+          }
+        } catch(error) {
+          Logger.log(error);
+          get(scope, 'notify').alert(config.messages.incorrectPassword);
+        }
+      }
+    }
   }
 });

--- a/addon/components/update-email.js
+++ b/addon/components/update-email.js
@@ -3,6 +3,7 @@ import layout from '../templates/components/update-email';
 import EmailValidations from '../validations/email';
 import Changeset from 'ember-changeset';
 import lookupValidator from 'ember-changeset-validations';
+import firebase from 'firebase';
 
 export default Ember.Component.extend({
   layout,
@@ -11,7 +12,6 @@ export default Ember.Component.extend({
   session: Ember.inject.service(),
   notify: Ember.inject.service(),
   'account-config': Ember.inject.service(),
-  reauthenticate: Ember.inject.service(),
   store: Ember.inject.service(),
   actions: {
     updateEmail(form) {
@@ -19,46 +19,55 @@ export default Ember.Component.extend({
       return new Ember.RSVP.Promise(function(resolve, reject) {
         if (scope.get('session.isAuthenticated') && scope.get('email').get('isValid')) {
           const currentUser = scope.get('firebaseApp').auth().currentUser;
-          currentUser.updateEmail(form.get('email')).then(() => {
-            if (scope.get('account-config').email) {
-              scope.get('store').findRecord('user', currentUser.uid).then((data) => {
-                data.set(scope.get('account-config').email, form.get('email'));
-                data.save().then(() => {
-                  scope.get('notify').success(scope.get('account-config').messages['successfulUpdateEmail']);
-                  resolve();
+
+          // Get credentials for reauthentication via the user email and the entered password
+          const credential = firebase.auth.EmailAuthProvider.credential(currentUser.email, form.get('currentPassword'));
+
+          currentUser.reauthenticate(credential).then(() => {
+
+            currentUser.updateEmail(form.get('email')).then(() => {
+              if (scope.get('account-config').email) {
+                scope.get('store').findRecord('user', currentUser.uid).then((data) => {
+                  data.set(scope.get('account-config').email, form.get('email'));
+
+                  data.save().then(() => {
+                    scope.get('notify').success(scope.get('account-config').messages['successfulUpdateEmail']);
+                    resolve();
+                  }, (error) => {
+                    scope.get('notify').alert(scope.get('account-config').messages['unsuccessfulUpdateEmail']);
+                    reject();
+                  });
+
                 }, (error) => {
                   scope.get('notify').alert(scope.get('account-config').messages['unsuccessfulUpdateEmail']);
                   reject();
                 });
-              }, (error) => {
-                scope.get('notify').alert(scope.get('account-config').messages['unsuccessfulUpdateEmail']);
-                reject();
-              });
-            }
-            else {
-              scope.get('notify').success(scope.get('account-config').messages['successfulUpdateEmail']);
-              resolve();
-            }
+              }
+              else {
+                scope.get('notify').success(scope.get('account-config').messages['successfulUpdateEmail']);
+                resolve();
+              }
+            }, (error) => {
+              Ember.Logger.log(error);
+              scope.get('notify').alert(scope.get('account-config').messages['unsuccessfulUpdateEmail']);
+              reject();
+            });
+
           }, (error) => {
             Ember.Logger.log(error);
-            if(error.code === 'auth/requires-recent-login') {
-              scope.get('notify').alert(scope.get('account-config').messages['unsuccessfulUpdateEmail']);
-              scope.get('reauthenticate').set('shouldReauthenticate', true);
-            }
+            scope.get('notify').alert(scope.get('account-config').messages['incorrectPassword']);
             reject();
           });
         }
+
         reject();
       });
     }
   },
-  shouldReauthenticate: Ember.computed('reauthenticate.shouldReauthenticate', function() {
-    return this.get('reauthenticate.shouldReauthenticate');
-  }),
   EmailValidations,
   init() {
     this._super(...arguments);
-    this.email = new Changeset({email: '', emailConfirmation: ''}, lookupValidator(EmailValidations), EmailValidations);
+    this.email = new Changeset({email: '', emailConfirmation: '', currentPassword: ''}, lookupValidator(EmailValidations), EmailValidations);
     this.currentEmail = this.get('firebaseApp').auth().currentUser.email;
     this.currentEmailPrompt = this.get('account-config').messages['currentEmailPrompt'];
   }

--- a/addon/components/update-password.js
+++ b/addon/components/update-password.js
@@ -8,7 +8,7 @@ import firebase from 'firebase';
 const {
   Component,
   inject: { service },
-  Logger,
+  Logger: { log },
   get
 } = Ember;
 
@@ -43,12 +43,12 @@ export default Component.extend({
             await get(scope, 'firebaseApp').auth().currentUser.updatePassword(get(form, 'password'));
             get(scope, 'notify').success(config.messages.successfulUpdatePassword);
           } catch(error) {
-            Logger.log(error);
+            log(error);
             get(scope, 'notify').alert(config.messages.unsuccessfulUpdatePassword);
           }
 
         } catch(error) {
-          Logger.log(error);
+          log(error);
           get(scope, 'notify').alert(config.messages.incorrectPassword);
         }
       }

--- a/addon/components/update-password.js
+++ b/addon/components/update-password.js
@@ -5,46 +5,53 @@ import Changeset from 'ember-changeset';
 import lookupValidator from 'ember-changeset-validations';
 import firebase from 'firebase';
 
-export default Ember.Component.extend({
+const {
+  Component,
+  inject,
+  Logger,
+  get
+} = Ember;
+
+export default Component.extend({
+  firebaseApp: inject.service(),
+  session: inject.service(),
+  notify: inject.service(),
+  'account-config': inject.service(),
   layout,
-  classNames: ['update-password-component'],
-  firebaseApp: Ember.inject.service(),
-  session: Ember.inject.service(),
-  notify: Ember.inject.service(),
-  'account-config': Ember.inject.service(),
-  actions: {
-    updatePassword(form) {
-      const scope = this;
-      return new Ember.RSVP.Promise(function(resolve, reject) {
-        if (scope.get('session.isAuthenticated') && scope.get('password').get('isValid')) {
-          const currentUser = scope.get('firebaseApp').auth().currentUser;
 
-          // Get credentials for reauthentication via the user email and the entered password
-          const credential = firebase.auth.EmailAuthProvider.credential(currentUser.email, form.get('currentPassword'));
-
-          currentUser.reauthenticate(credential).then(() => {
-
-            scope.get('firebaseApp').auth().currentUser.updatePassword(form.get('password')).then(() => {
-              scope.get('notify').success(scope.get('account-config').messages['successfulUpdatePassword']);
-              resolve();
-            }, (error) => {
-              Ember.Logger.log(error);
-              scope.get('notify').alert(scope.get('account-config').messages['unsuccessfulUpdatePassword']);
-              reject();
-            });
-          }, (error) => {
-            Ember.Logger.log(error);
-            scope.get('notify').alert(scope.get('account-config').messages['incorrectPassword']);
-            reject();
-          });
-        }
-
-        reject();
-      });
-    }
-  },
   init() {
     this._super();
-    this.password = new Changeset({password: '', passwordConfirmation: '', currentPassword: ''}, lookupValidator(PasswordValidations), PasswordValidations);
+    this.password = new Changeset({ password: '', passwordConfirmation: '', currentPassword: '' }, lookupValidator(PasswordValidations), PasswordValidations);
+    this.classNames = ['update-password-component'];
+  },
+
+  actions: {
+    async updatePassword(form) {
+      let scope = this;
+      let config = get(scope, 'account-config');
+
+      if (get(scope, 'session.isAuthenticated') && get(get(scope, 'password'), 'isValid')) {
+        let currentUser = get(scope, 'firebaseApp').auth().currentUser; // eslint-disable-line ember-suave/prefer-destructuring
+
+        // Get credentials for reauthentication via the user email and the entered password
+        let credential = firebase.auth.EmailAuthProvider.credential(currentUser.email, get(form, 'currentPassword'));
+
+        try {
+          await currentUser.reauthenticate(credential);
+
+          try {
+            await get(scope, 'firebaseApp').auth().currentUser.updatePassword(get(form, 'password'));
+            get(scope, 'notify').success(config.messages.successfulUpdatePassword);
+          } catch(error) {
+            Logger.log(error);
+            get(scope, 'notify').alert(config.messages.unsuccessfulUpdatePassword);
+          }
+
+        } catch(error) {
+          Logger.log(error);
+          get(scope, 'notify').alert(config.messages.incorrectPassword);
+        }
+      }
+    }
   }
 });

--- a/addon/components/update-password.js
+++ b/addon/components/update-password.js
@@ -7,16 +7,16 @@ import firebase from 'firebase';
 
 const {
   Component,
-  inject,
+  inject: { service },
   Logger,
   get
 } = Ember;
 
 export default Component.extend({
-  firebaseApp: inject.service(),
-  session: inject.service(),
-  notify: inject.service(),
-  'account-config': inject.service(),
+  firebaseApp: service(),
+  session: service(),
+  notify: service(),
+  'account-config': service(),
   layout,
 
   init() {

--- a/addon/components/update-password.js
+++ b/addon/components/update-password.js
@@ -3,6 +3,7 @@ import layout from '../templates/components/update-password';
 import PasswordValidations from '../validations/password';
 import Changeset from 'ember-changeset';
 import lookupValidator from 'ember-changeset-validations';
+import firebase from 'firebase';
 
 export default Ember.Component.extend({
   layout,
@@ -11,32 +12,39 @@ export default Ember.Component.extend({
   session: Ember.inject.service(),
   notify: Ember.inject.service(),
   'account-config': Ember.inject.service(),
-  reauthenticate: Ember.inject.service(),
   actions: {
     updatePassword(form) {
       const scope = this;
       return new Ember.RSVP.Promise(function(resolve, reject) {
         if (scope.get('session.isAuthenticated') && scope.get('password').get('isValid')) {
-          scope.get('firebaseApp').auth().currentUser.updatePassword(form.get('password')).then(() => {
-            scope.get('notify').success(scope.get('account-config').messages['successfulUpdatePassword']);
-            resolve();
-          }, (error) => {
-            if(error.code === 'auth/requires-recent-login') {
+          const currentUser = scope.get('firebaseApp').auth().currentUser;
+
+          // Get credentials for reauthentication via the user email and the entered password
+          const credential = firebase.auth.EmailAuthProvider.credential(currentUser.email, form.get('currentPassword'));
+
+          currentUser.reauthenticate(credential).then(() => {
+
+            scope.get('firebaseApp').auth().currentUser.updatePassword(form.get('password')).then(() => {
+              scope.get('notify').success(scope.get('account-config').messages['successfulUpdatePassword']);
+              resolve();
+            }, (error) => {
+              Ember.Logger.log(error);
               scope.get('notify').alert(scope.get('account-config').messages['unsuccessfulUpdatePassword']);
-              scope.get('reauthenticate').set('shouldReauthenticate', true);
-            }
+              reject();
+            });
+          }, (error) => {
+            Ember.Logger.log(error);
+            scope.get('notify').alert(scope.get('account-config').messages['incorrectPassword']);
             reject();
           });
         }
+
         reject();
       });
     }
   },
-  shouldReauthenticate: Ember.computed('reauthenticate.shouldReauthenticate', function() {
-    return this.get('reauthenticate.shouldReauthenticate');
-  }),
   init() {
     this._super();
-    this.password = new Changeset({password: '', passwordConfirmation: ''}, lookupValidator(PasswordValidations), PasswordValidations);
+    this.password = new Changeset({password: '', passwordConfirmation: '', currentPassword: ''}, lookupValidator(PasswordValidations), PasswordValidations);
   }
 });

--- a/addon/components/verify-email.js
+++ b/addon/components/verify-email.js
@@ -1,30 +1,40 @@
 import Ember from 'ember';
 import layout from '../templates/components/verify-email';
 
-export default Ember.Component.extend({
-  layout,
-  classNames: ['verify-email-component'],
-  firebaseApp: Ember.inject.service(),
-  notify: Ember.inject.service(),
-  'account-config': Ember.inject.service(),
+const {
+  Component,
+  inject,
+  get,
+  set
+} = Ember;
+
+export default Component.extend({
+  firebaseApp: inject.service(),
+  notify: inject.service(),
+  'account-config': inject.service(),
   isVerified: false,
-  actions: {
-    sendEmailVerification() {
-      const user = this.get('firebaseApp').auth().currentUser;
-      if (!user.emailVerified) {
-        user.sendEmailVerification().then(() => {
-          this.get('notify').info('Email verification was sent, please check your inbox');
-        }, (error) => {
-          this.get('notify').alert(`Error: ${error.code}`);
-        });
-      }
-      else {
-        this.get('notify').alert(`Error: Your email is already verified`);
-      }
-    }
-  },
+  layout,
+
   init() {
     this._super(...arguments);
-    this.set('isVerified', this.get('firebaseApp').auth().currentUser.emailVerified );
+    set(this, 'isVerified', get(this, 'firebaseApp').auth().currentUser.emailVerified);
+    this.classNames = ['verify-email-component'];
+  },
+
+  actions: {
+    async sendEmailVerification() {
+      let user = get(this, 'firebaseApp').auth().currentUser;
+
+      if (!user.emailVerified) {
+        try {
+          await user.sendEmailVerification();
+          get(this, 'notify').info('Email verification was sent, please check your inbox');
+        } catch(error) {
+          get(this, 'notify').alert(`Error: ${error.code}`);
+        }
+      } else {
+        get(this, 'notify').alert('Error: Your email is already verified');
+      }
+    }
   }
 });

--- a/addon/components/verify-email.js
+++ b/addon/components/verify-email.js
@@ -3,15 +3,15 @@ import layout from '../templates/components/verify-email';
 
 const {
   Component,
-  inject,
+  inject: { service },
   get,
   set
 } = Ember;
 
 export default Component.extend({
-  firebaseApp: inject.service(),
-  notify: inject.service(),
-  'account-config': inject.service(),
+  firebaseApp: service(),
+  notify: service(),
+  'account-config': service(),
   isVerified: false,
   layout,
 

--- a/addon/router.js
+++ b/addon/router.js
@@ -1,6 +1,6 @@
 export default function(router) {
   router.route('account', function() {
-    this.route('portal', {path: '/'});
+    this.route('portal', { path: '/' });
     this.route('email');
     this.route('delete');
     this.route('password');

--- a/addon/routes/account.js
+++ b/addon/routes/account.js
@@ -2,15 +2,17 @@ import Ember from 'ember';
 
 const {
   Route,
-  inject: { service }
+  inject: { service },
+  get
 } = Ember;
 
 export default Route.extend({
   session: service(),
-  'account-config': Ember.inject.service(),
+  'account-config': service(),
+
   beforeModel() {
-    if (this.get('account-config').signInLink && !this.get('session.isAuthenticated')){
-      this.get('router').transitionTo(Object.keys(this.get('account-config').signInLink)[0]);
+    if (get(this, 'account-config').signInLink && !get(this, 'session.isAuthenticated')) {
+      get(this, 'router').transitionTo(Object.keys(get(this, 'account-config').signInLink)[0]);
     }
   }
 });

--- a/addon/routes/account/portal.js
+++ b/addon/routes/account/portal.js
@@ -2,15 +2,17 @@ import Ember from 'ember';
 
 const {
   inject: { service },
-  Route
+  Route,
+  get
 } = Ember;
 
 export default Route.extend({
   session: service(),
-  'account-config': Ember.inject.service(),
+  'account-config': service(),
+
   beforeModel() {
-    if (this.get('account-config').portalLink) {
-      this.get('router').transitionTo(Object.keys(this.get('account-config').portalLink)[0]);
+    if (get(this, 'account-config').portalLink) {
+      get(this, 'router').transitionTo(Object.keys(get(this, 'account-config').portalLink)[0]);
     }
   }
 });

--- a/addon/services/account-config.js
+++ b/addon/services/account-config.js
@@ -1,5 +1,7 @@
 import Ember from 'ember';
 
-export default Ember.Service.extend({
-	
+const { Service } = Ember;
+
+export default Service.extend({
+
 });

--- a/addon/services/reauthenticate.js
+++ b/addon/services/reauthenticate.js
@@ -5,5 +5,5 @@ const {
 } = Ember;
 
 export default Service.extend({
-  shouldReauthenticate: false,
+  shouldReauthenticate: false
 });

--- a/addon/services/reauthenticate.js
+++ b/addon/services/reauthenticate.js
@@ -1,7 +1,6 @@
 import Ember from 'ember';
 const {
   Service
-  // set
 } = Ember;
 
 export default Service.extend({

--- a/addon/templates/account.hbs
+++ b/addon/templates/account.hbs
@@ -1,10 +1,10 @@
 {{#if session.isAuthenticated}}
-	<div class="ef-account">
-		<div class="ef-account-sidebar">
-			{{#account-menu}}{{/account-menu}}
-		</div>
-		{{outlet}}
-	</div>
+  <div class="ef-account">
+    <div class="ef-account-sidebar">
+      {{#account-menu}}{{/account-menu}}
+    </div>
+    {{outlet}}
+  </div>
 {{else}}
-	You need to be signed in to view your account info.
+  You need to be signed in to view your account info.
 {{/if}}

--- a/addon/templates/components/account-menu.hbs
+++ b/addon/templates/components/account-menu.hbs
@@ -2,7 +2,7 @@
 	{{#each-in links as |l title|}}
 		{{#link-to l}}
 			<div class='account-btn'>
-				{{title}}
+				{{{title}}}
 			</div>
 		{{/link-to}}
 	{{/each-in}}

--- a/addon/templates/components/delete-user.hbs
+++ b/addon/templates/components/delete-user.hbs
@@ -1,13 +1,9 @@
 <div class="ef-account-form">
 	<h1 class="ef-account-form-title">Delete Account</h1>
-	{{#if shouldReauthenticate}}
-		{{#re-authenticate}}{{/re-authenticate}}
-	{{else}}
-		{{#form-for delete_form submit=(action 'deleteUser') as |f|}}
-			<div class="ef-account-form-input">
-				{{f.email-field "email" label="Email" }}
-			</div>
-			{{f.submit "Delete Your Account" class="common-button"}}
-		{{/form-for}}
-	{{/if}}
+	{{#form-for delete_form submit=(action 'deleteUser') as |f|}}
+		<div class="ef-account-form-input">
+			{{f.password-field "currentPassword" label="Current Password" }}
+		</div>
+		{{f.submit "Delete Your Account" class="common-button"}}
+	{{/form-for}}
 </div>

--- a/addon/templates/components/delete-user.hbs
+++ b/addon/templates/components/delete-user.hbs
@@ -1,6 +1,6 @@
 <div class="ef-account-form">
 	<h1 class="ef-account-form-title">Delete Account</h1>
-	{{#form-for delete_form submit=(action 'deleteUser') as |f|}}
+	{{#form-for deleteForm submit=(action 'deleteUser') as |f|}}
 		<div class="ef-account-form-input">
 			{{f.password-field "currentPassword" label="Current Password" }}
 		</div>

--- a/addon/templates/components/re-authenticate.hbs
+++ b/addon/templates/components/re-authenticate.hbs
@@ -1,15 +1,15 @@
 <div class="ef-account-form">
-	{{#if reauthenticate.shouldReauthenticate}}
-		<h1 class="ef-account-form-title">It's been a long time since you last logged in so for security please re-enter your credentials.</h1>
-	  {{#form-for creds submit=(action 'reauthenticate') class="reauthenticate-form" as |f|}}
-		  <div class="ef-account-form-input">
-		    {{f.text-field "email" label="Email"}}
-		    <br>
-		    {{f.password-field "password" label="Password"}}
-		  </div>
-		    {{f.submit "Sign In" class="common-button"}}
-	  {{/form-for}}
-	{{else}}
-	  {{yield}}
-	{{/if}}
+  {{#if reauthenticate.shouldReauthenticate}}
+    <h1 class="ef-account-form-title">It's been a long time since you last logged in so for security please re-enter your credentials.</h1>
+    {{#form-for creds submit=(action 'reauthenticate') class="reauthenticate-form" as |f|}}
+      <div class="ef-account-form-input">
+        {{f.text-field "email" label="Email"}}
+        <br>
+        {{f.password-field "password" label="Password"}}
+      </div>
+      {{f.submit "Sign In" class="common-button"}}
+    {{/form-for}}
+  {{else}}
+    {{yield}}
+  {{/if}}
 </div>

--- a/addon/templates/components/re-authenticate.hbs
+++ b/addon/templates/components/re-authenticate.hbs
@@ -4,7 +4,7 @@
 	  {{#form-for creds submit=(action 'reauthenticate') class="reauthenticate-form" as |f|}}
 		  <div class="ef-account-form-input">
 		    {{f.text-field "email" label="Email"}}
-		   	<br>
+		    <br>
 		    {{f.password-field "password" label="Password"}}
 		  </div>
 		    {{f.submit "Sign In" class="common-button"}}

--- a/addon/templates/components/update-email.hbs
+++ b/addon/templates/components/update-email.hbs
@@ -4,6 +4,7 @@
 		{{#re-authenticate}}{{/re-authenticate}}
 	{{else}}
 		{{#form-for email submit=(action 'updateEmail') as |f|}}
+			<div>{{{currentEmailPrompt}}}{{currentEmail}}</div>
 			<div class="ef-account-form-input">
 				{{f.email-field "email" label="Email" }}
 				<br>

--- a/addon/templates/components/update-email.hbs
+++ b/addon/templates/components/update-email.hbs
@@ -1,16 +1,14 @@
 <div class="ef-account-form">
 	<h1 class="ef-account-form-title">Update Email</h1>
-	{{#if shouldReauthenticate}}
-		{{#re-authenticate}}{{/re-authenticate}}
-	{{else}}
-		{{#form-for email submit=(action 'updateEmail') as |f|}}
-			<div>{{{currentEmailPrompt}}}{{currentEmail}}</div>
-			<div class="ef-account-form-input">
-				{{f.email-field "email" label="Email" }}
-				<br>
-				{{f.email-field "emailConfirmation" label="Email Confirmation" }}
-			</div>
-			{{f.submit "Update Info" class="common-button"}}
-		{{/form-for}}
-	{{/if}}
+	{{#form-for email submit=(action 'updateEmail') as |f|}}
+		<div>{{{currentEmailPrompt}}}{{currentEmail}}</div>
+		<div class="ef-account-form-input">
+			{{f.password-field "currentPassword" label="Current Password" }}
+			<br>
+			{{f.email-field "email" label="Email" }}
+			<br>
+			{{f.email-field "emailConfirmation" label="Email Confirmation" }}
+		</div>
+		{{f.submit "Update Info" class="common-button"}}
+	{{/form-for}}
 </div>

--- a/addon/templates/components/update-email.hbs
+++ b/addon/templates/components/update-email.hbs
@@ -1,7 +1,7 @@
 <div class="ef-account-form">
 	<h1 class="ef-account-form-title">Update Email</h1>
 	{{#form-for email submit=(action 'updateEmail') as |f|}}
-		<div>{{{currentEmailPrompt}}}{{currentEmail}}</div>
+		<div class="ef-account-caption">{{{currentEmailPrompt}}}{{currentEmail}}</div>
 		<div class="ef-account-form-input">
 			{{f.password-field "currentPassword" label="Current Password" }}
 			<br>

--- a/addon/templates/components/update-email.hbs
+++ b/addon/templates/components/update-email.hbs
@@ -1,14 +1,14 @@
 <div class="ef-account-form">
-	<h1 class="ef-account-form-title">Update Email</h1>
-	{{#form-for email submit=(action 'updateEmail') as |f|}}
-		<div class="ef-account-caption">{{{currentEmailPrompt}}}{{currentEmail}}</div>
-		<div class="ef-account-form-input">
-			{{f.password-field "currentPassword" label="Current Password" }}
-			<br>
-			{{f.email-field "email" label="Email" }}
-			<br>
-			{{f.email-field "emailConfirmation" label="Email Confirmation" }}
-		</div>
-		{{f.submit "Update Info" class="common-button"}}
-	{{/form-for}}
+  <h1 class="ef-account-form-title">Update Email</h1>
+  {{#form-for email submit=(action 'updateEmail') as |f|}}
+    <div class="ef-account-caption">{{{currentEmailPrompt}}}{{currentEmail}}</div>
+    <div class="ef-account-form-input">
+      {{f.password-field "currentPassword" label="Current Password" }}
+      <br>
+      {{f.email-field "email" label="Email" }}
+      <br>
+      {{f.email-field "emailConfirmation" label="Email Confirmation" }}
+    </div>
+    {{f.submit "Update Info" class="common-button"}}
+  {{/form-for}}
 </div>

--- a/addon/templates/components/update-password.hbs
+++ b/addon/templates/components/update-password.hbs
@@ -4,9 +4,9 @@
 		<div class="ef-account-form-input">
 			{{f.password-field "currentPassword" label="Current Password" }}
 			<br>
-			{{f.password-field "password" label="Password" }}
+			{{f.password-field "password" label="New Password" }}
 			<br>
-			{{f.password-field "passwordConfirmation" label="Password Confirmation" }}
+			{{f.password-field "passwordConfirmation" label="New Password Confirmation" }}
 		</div>
 		{{f.submit "Update Password" class="common-button"}}
 	{{/form-for}}

--- a/addon/templates/components/update-password.hbs
+++ b/addon/templates/components/update-password.hbs
@@ -1,15 +1,13 @@
 <div class="ef-account-form">
 	<h1 class="ef-account-form-title">Change Password</h1>
-	{{#if shouldReauthenticate}}
-		{{#re-authenticate}}{{/re-authenticate}}
-	{{else}}
-		{{#form-for password submit=(action 'updatePassword') as |f|}}
-			<div class="ef-account-form-input">
-				{{f.password-field "password" label="Password" }}
-				<br>
-				{{f.password-field "passwordConfirmation" label="Password Confirmation" }}
-			</div>
-			{{f.submit "Update Password" class="common-button"}}
-		{{/form-for}}
-	{{/if}}
+	{{#form-for password submit=(action 'updatePassword') as |f|}}
+		<div class="ef-account-form-input">
+			{{f.password-field "currentPassword" label="Current Password" }}
+			<br>
+			{{f.password-field "password" label="Password" }}
+			<br>
+			{{f.password-field "passwordConfirmation" label="Password Confirmation" }}
+		</div>
+		{{f.submit "Update Password" class="common-button"}}
+	{{/form-for}}
 </div>

--- a/addon/templates/components/update-password.hbs
+++ b/addon/templates/components/update-password.hbs
@@ -1,13 +1,13 @@
 <div class="ef-account-form">
-	<h1 class="ef-account-form-title">Change Password</h1>
-	{{#form-for password submit=(action 'updatePassword') as |f|}}
-		<div class="ef-account-form-input">
-			{{f.password-field "currentPassword" label="Current Password" }}
-			<br>
-			{{f.password-field "password" label="New Password" }}
-			<br>
-			{{f.password-field "passwordConfirmation" label="New Password Confirmation" }}
-		</div>
-		{{f.submit "Update Password" class="common-button"}}
-	{{/form-for}}
+  <h1 class="ef-account-form-title">Change Password</h1>
+  {{#form-for password submit=(action 'updatePassword') as |f|}}
+    <div class="ef-account-form-input">
+      {{f.password-field "currentPassword" label="Current Password" }}
+      <br>
+      {{f.password-field "password" label="New Password" }}
+      <br>
+      {{f.password-field "passwordConfirmation" label="New Password Confirmation" }}
+    </div>
+    {{f.submit "Update Password" class="common-button"}}
+  {{/form-for}}
 </div>

--- a/addon/templates/components/verify-email.hbs
+++ b/addon/templates/components/verify-email.hbs
@@ -1,8 +1,8 @@
 <div class="ef-account-form">
-	<h1 class="ef-account-form-title">Send Email Verification</h1>
-	{{#if isVerified}}
-		<p>You have already verified your email</p>
-	{{else}}
-		<button class="common-button" {{action "sendEmailVerification"}}>Send Email</button>
-	{{/if}}
+  <h1 class="ef-account-form-title">Send Email Verification</h1>
+  {{#if isVerified}}
+    <p>You have already verified your email</p>
+  {{else}}
+    <button class="common-button" {{action "sendEmailVerification"}}>Send Email</button>
+  {{/if}}
 </div>

--- a/addon/validations/email.js
+++ b/addon/validations/email.js
@@ -3,13 +3,13 @@ import {
   validatePresence,
   validateFormat,
   // validateLength,
-  validateConfirmation,
+  validateConfirmation
 } from 'ember-changeset-validations/validators';
 
 export default {
   email: [
     validatePresence(true),
-    validateFormat({type: 'email'})
+    validateFormat({ type: 'email' })
   ],
   emailConfirmation: validateConfirmation({ on: 'email' })
 };

--- a/addon/validations/password.js
+++ b/addon/validations/password.js
@@ -2,7 +2,7 @@
 import {
   validatePresence,
   validateLength,
-  validateConfirmation,
+  validateConfirmation
 } from 'ember-changeset-validations/validators';
 
 export default {

--- a/addon/validations/reauthenticate.js
+++ b/addon/validations/reauthenticate.js
@@ -1,11 +1,12 @@
 import {
   validatePresence,
-  validateFormat,
+  validateFormat
 } from 'ember-changeset-validations/validators';
+
 export default {
   email: [
     validatePresence(true),
     validateFormat({ type: 'email' })
   ],
-  password: validatePresence(true),
+  password: validatePresence(true)
 };

--- a/app/instance-initializers/config-initializer.js
+++ b/app/instance-initializers/config-initializer.js
@@ -1,43 +1,42 @@
 import Ember from 'ember';
 import config from '../config/environment';
 
-
 const DEFAULT_CONFIG = {
-    hardDelete: false,
-    links: {
-      'account.delete': 'Delete Account',
-      'account.email': 'Update Email',
-      'account.password': 'Change Password',
-      'account.verify-email': 'Send Email Verification'
-    },
-    messages: {
-      successfulLogin: 'You have logged in successfully!',
-      unsuccessfulLogin: 'You were unable to log in.',
-      successfulUpdateAccount: 'You have successfully updated your account information!',
-      unsuccessfulUpdateAccount: 'We were unable to update your account information.',
-      successfulUpdateEmail: 'You have successfully updated your email!',
-      unsuccessfulUpdateEmail: 'We were unable to update your email.',
-      successfulUpdatePassword: 'You have successfully updated your password!',
-      unsuccessfulUpdatePassword: 'We were unable to update your password.',
-      successfulDeleteAccount: 'You have successfully deleted your account!',
-      unsuccessfulDeleteAccount: 'We were unable to delete your account.',
-      successfulLogout: 'You are now logged out!',
-      unsuccessfulLogout: 'We were unable to log out of your account.',
-      successfulCreateAccount: 'You have created an account successfully!',
-      unsuccessfulCreateAccount: 'We were unable to create your account.',
-      currentEmailPrompt: 'Your current account email adress is: ',
-      incorrectPassword: 'That is an incorrect password.'
-    }
+  hardDelete: false,
+  links: {
+    'account.delete': 'Delete Account',
+    'account.email': 'Update Email',
+    'account.password': 'Change Password',
+    'account.verify-email': 'Send Email Verification'
+  },
+  messages: {
+    successfulLogin: 'You have logged in successfully!',
+    unsuccessfulLogin: 'You were unable to log in.',
+    successfulUpdateAccount: 'You have successfully updated your account information!',
+    unsuccessfulUpdateAccount: 'We were unable to update your account information.',
+    successfulUpdateEmail: 'You have successfully updated your email!',
+    unsuccessfulUpdateEmail: 'We were unable to update your email.',
+    successfulUpdatePassword: 'You have successfully updated your password!',
+    unsuccessfulUpdatePassword: 'We were unable to update your password.',
+    successfulDeleteAccount: 'You have successfully deleted your account!',
+    unsuccessfulDeleteAccount: 'We were unable to delete your account.',
+    successfulLogout: 'You are now logged out!',
+    unsuccessfulLogout: 'We were unable to log out of your account.',
+    successfulCreateAccount: 'You have created an account successfully!',
+    unsuccessfulCreateAccount: 'We were unable to create your account.',
+    currentEmailPrompt: 'Your current account email adress is: ',
+    incorrectPassword: 'That is an incorrect password.'
+  }
 };
 
 const { merge, set } = Ember;
 
-export function initialize( appInstance ) {
-  let configService = appInstance.lookup('service:account-config'),
-      efConfig = {};
+export function initialize(appInstance) {
+  let configService = appInstance.lookup('service:account-config');
+  let efConfig = {};
 
-  Object.keys(DEFAULT_CONFIG).forEach((key) => {
-      efConfig = merge(DEFAULT_CONFIG, config['emberfire-account']);
+  Object.keys(DEFAULT_CONFIG).forEach(() => {
+    efConfig = merge(DEFAULT_CONFIG, config['emberfire-account']);
   });
 
   Object.keys(efConfig).forEach((key) => {

--- a/app/instance-initializers/config-initializer.js
+++ b/app/instance-initializers/config-initializer.js
@@ -24,7 +24,8 @@ const DEFAULT_CONFIG = {
       successfulLogout: 'You are now logged out!',
       unsuccessfulLogout: 'We were unable to log out of your account.',
       successfulCreateAccount: 'You have created an account successfully!',
-      unsuccessfulCreateAccount: 'We were unable to create your account.'
+      unsuccessfulCreateAccount: 'We were unable to create your account.',
+      currentEmailPrompt: 'Your current account email adress is: '
     }
 };
 

--- a/app/instance-initializers/config-initializer.js
+++ b/app/instance-initializers/config-initializer.js
@@ -25,7 +25,8 @@ const DEFAULT_CONFIG = {
       unsuccessfulLogout: 'We were unable to log out of your account.',
       successfulCreateAccount: 'You have created an account successfully!',
       unsuccessfulCreateAccount: 'We were unable to create your account.',
-      currentEmailPrompt: 'Your current account email adress is: '
+      currentEmailPrompt: 'Your current account email adress is: ',
+      incorrectPassword: 'That is an incorrect password.'
     }
 };
 

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,4 +1,4 @@
-/*jshint node:true*/
+/* eslint-disable */
 module.exports = {
   scenarios: [
     // {

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,4 +1,4 @@
-/*jshint node:true*/
+/* eslint-disable */
 'use strict';
 
 module.exports = function(environment) {

--- a/config/environment.js
+++ b/config/environment.js
@@ -3,9 +3,9 @@
 
 module.exports = function(environment) {
   const ENV = {
-  	'emberfire-account': {
-  		hardDelete: false
-  	}
+    'emberfire-account': {
+      hardDelete: false
+    }
   }
 
   return ENV;

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,4 +1,4 @@
-/*jshint node:true*/
+/* eslint-disable */
 /* global require, module */
 var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-/* jshint node: true */
+/* eslint-disable */
 'use strict';
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
     "ember-cli-mocha": "0.14.4",
     "ember-data": "2.11.0",
     "ember-form-for": "2.0.0-alpha.15",
-    "ember-notify": "5.2.0",
     "emberfire": "firebase/emberfire"
   },
   "devDependencies": {
+    "ember-notify": "5.2.0",
     "broccoli-asset-rev": "2.4.5",
     "ember-ajax": "2.4.1",
     "ember-cli": "2.11.1",

--- a/testem.js
+++ b/testem.js
@@ -1,4 +1,4 @@
-/*jshint node:true*/
+/* eslint-disable */
 module.exports = {
   "framework": "qunit",
   "test_page": "tests/index.html?hidepassed",

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -5,9 +5,13 @@ import config from './config/environment';
 
 let App;
 
+const {
+  Application
+} = Ember;
+
 Ember.MODEL_FACTORY_INJECTIONS = true;
 
-App = Ember.Application.extend({
+App = Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,
   Resolver

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -1,12 +1,16 @@
 import Ember from 'ember';
 import config from './config/environment';
 
-const Router = Ember.Router.extend({
+const {
+  Router
+} = Ember;
+
+const AppRouter = Router.extend({
   location: config.locationType,
   rootURL: config.rootURL
 });
 
-Router.map(function() {
+AppRouter.map(function() {
 });
 
-export default Router;
+export default AppRouter;

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -1,4 +1,4 @@
-/* jshint node: true */
+/* eslint-disable */
 
 module.exports = function(environment) {
   var ENV = {

--- a/tests/helpers/destroy-app.js
+++ b/tests/helpers/destroy-app.js
@@ -1,5 +1,9 @@
 import Ember from 'ember';
 
+const {
+  run
+} = Ember;
+
 export default function destroyApp(application) {
-  Ember.run(application, 'destroy');
+  run(application, 'destroy');
 }

--- a/tests/helpers/module-for-acceptance.js
+++ b/tests/helpers/module-for-acceptance.js
@@ -15,9 +15,10 @@ export default function(name, options = {}) {
       }
     },
 
-    afterEach() {
+    async afterEach() {
       let afterEach = options.afterEach && options.afterEach.apply(this, arguments);
-      return Promise.resolve(afterEach).then(() => destroyApp(this.application));
+      await Promise.resolve(afterEach);
+      destroyApp(this.application);
     }
   });
 }

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -2,13 +2,18 @@ import Ember from 'ember';
 import Application from '../../app';
 import config from '../../config/environment';
 
+const {
+  merge,
+  run
+} = Ember;
+
 export default function startApp(attrs) {
   let application;
 
-  let attributes = Ember.merge({}, config.APP);
-  attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
+  let attributes = merge({}, config.APP);
+  attributes = merge(attributes, attrs); // use defaults, but you can override;
 
-  Ember.run(() => {
+  run(() => {
     application = Application.create(attributes);
     application.setupForTesting();
     application.injectTestHelpers();

--- a/tests/integration/components/account-menu-test.js
+++ b/tests/integration/components/account-menu-test.js
@@ -2,15 +2,19 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 
-const configStub = Ember.Service.extend({
-  links: {
+const {
+  Service
+} = Ember;
+
+const configStub = Service.extend({
+  links: { // eslint-disable-line ember/avoid-leaking-state-in-components
     'account.test': 'Test Link'
   }
 });
 
 moduleForComponent('account-menu', 'Integration | Component | account menu', {
   integration: true,
-  beforeEach(){
+  beforeEach() {
     this.register('service:account-config', configStub);
   }
 });
@@ -18,5 +22,5 @@ moduleForComponent('account-menu', 'Integration | Component | account menu', {
 test('it renders', function(assert) {
   this.render(hbs`{{#account-menu}}{{/account-menu}}`);
 
-  assert.equal(this.$().text().trim().substring(0, 9), "Test Link");
+  assert.equal(this.$().text().trim().substring(0, 9), 'Test Link');
 });

--- a/tests/integration/components/re-authenticate-test.js
+++ b/tests/integration/components/re-authenticate-test.js
@@ -2,39 +2,46 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 
-// const sessionStub = Ember.Service.extend({
+// const sessionStub = Service.extend({
 //   isAuthenticated: true
 // });
 
-const firebaseStub = Ember.Service.extend({
-  auth(){
-    let shouldFail = this.get('shouldFail');
+const {
+  Service,
+  RSVP,
+  get,
+  set
+} = Ember;
+
+const firebaseStub = Service.extend({
+  shouldFail: false,
+
+  auth() {
+    let shouldFail = get(this, 'shouldFail');
     return {
       currentUser: {
-        email: "example@test.com",
-        reauthenticate(){
-          return new Ember.RSVP.Promise((resolve, reject) => {
-            if (shouldFail){
-              reject({code: 'error'});
-            }else{
+        email: 'example@test.com',
+        reauthenticate() {
+          return new RSVP.Promise((resolve, reject) => {
+            if (shouldFail) {
+              reject({ code: 'error' });
+            } else {
               resolve();
             }
           });
-        },
+        }
       }
     };
-  },
-  shouldFail: false
+  }
 });
 
-
-const reauthenticateStub = Ember.Service.extend({
+const reauthenticateStub = Service.extend({
   shouldReauthenticate: true
 });
 
 moduleForComponent('re-authenticate', 'Integration | Component | re authenticate', {
   integration: true,
-  beforeEach(){
+  beforeEach() {
     // this.register('service:session', sessionStub);
     this.register('service:firebaseApp', firebaseStub);
     this.inject.service('firebaseApp');
@@ -50,51 +57,51 @@ test('it renders', function(assert) {
   assert.equal(this.$().text().trim().substring(0, 16), 'Reauthentication');
 });
 
-test(('Correct submission'), function(assert){
+test(('Correct submission'), function(assert) {
   this.render(hbs`{{#re-authenticate}}{{/re-authenticate}}`);
 
-  this.$('input').first().val("new@example.com").trigger('change');
-  this.$('input').last().val("password").trigger('change');
+  this.$('input').first().val('new@example.com').trigger('change');
+  this.$('input').last().val('password').trigger('change');
   this.$('button').click();
 
-  assert.notOk(this.get('reauthenticate.shouldReauthenticate'));
+  assert.notOk(get(this, 'reauthenticate.shouldReauthenticate'));
 });
 
-test(('If the email is invalid, it should not pass'), function(assert){
+test(('If the email is invalid, it should not pass'), function(assert) {
   this.render(hbs`{{#re-authenticate}}{{/re-authenticate}}`);
 
-  this.$('input').first().val("notanemail").trigger('change');
-  this.$('input').last().val("notanemail").trigger('change');
+  this.$('input').first().val('notanemail').trigger('change');
+  this.$('input').last().val('notanemail').trigger('change');
   this.$('button').click();
 
-  assert.ok(this.get('reauthenticate.shouldReauthenticate'));
+  assert.ok(get(this, 'reauthenticate.shouldReauthenticate'));
 });
 
-test(("Email is required"), function(assert){
+test(('Email is required'), function(assert) {
   this.render(hbs`{{#re-authenticate}}{{/re-authenticate}}`);
 
-  this.$('input').last().val("password").trigger('change');
+  this.$('input').last().val('password').trigger('change');
   this.$('button').click();
 
-  assert.ok(this.get('reauthenticate.shouldReauthenticate'));
+  assert.ok(get(this, 'reauthenticate.shouldReauthenticate'));
 });
 
-test(("Password is required"), function(assert){
+test(('Password is required'), function(assert) {
   this.render(hbs`{{#re-authenticate}}{{/re-authenticate}}`);
 
-  this.$('input').first().val("test@example.com").trigger('change');
+  this.$('input').first().val('test@example.com').trigger('change');
   this.$('button').click();
 
-  assert.ok(this.get('reauthenticate.shouldReauthenticate'));
+  assert.ok(get(this, 'reauthenticate.shouldReauthenticate'));
 });
 
-test(("Reauth will fail if firebaseApp returns failure"), function(assert){
-  this.set('firebaseApp.shouldFail', true);
+test(('Reauth will fail if firebaseApp returns failure'), function(assert) {
+  set(this, 'firebaseApp.shouldFail', true);
   this.render(hbs`{{#re-authenticate}}{{/re-authenticate}}`);
 
-  this.$('input').first().val("new@example.com").trigger('change');
-  this.$('input').last().val("password").trigger('change');
+  this.$('input').first().val('new@example.com').trigger('change');
+  this.$('input').last().val('password').trigger('change');
   this.$('button').click();
 
-  assert.ok(this.get('reauthenticate.shouldReauthenticate'));
+  assert.ok(get(this, 'reauthenticate.shouldReauthenticate'));
 });

--- a/tests/integration/components/update-email-test.js
+++ b/tests/integration/components/update-email-test.js
@@ -2,55 +2,64 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 
-const sessionStub = Ember.Service.extend({
+const {
+  Service,
+  RSVP,
+  get,
+  set
+} = Ember;
+
+const sessionStub = Service.extend({
   isAuthenticated: true
 });
 
-const firebaseStub = Ember.Service.extend({
-  auth(){
-    let reauth = this.get('needReauth');
+const firebaseStub = Service.extend({
+  needReauth: false,
+
+  auth() {
+    let reauth = get(this, 'needReauth');
     return {
       currentUser: {
-        email: "example@test.com",
-        updateEmail(){
-          return new Ember.RSVP.Promise((resolve, reject) => {
-            if (reauth){
-              reject({code: 'auth/requires-recent-login'});
-            }else{
+        email: 'example@test.com',
+        updateEmail() {
+          return new RSVP.Promise((resolve, reject) => {
+            if (reauth) {
+              reject({ code: 'auth/requires-recent-login' });
+            } else {
               resolve();
             }
           });
-        },
+        }
       }
     };
-  },
-  needReauth: false
+  }
+
 });
 
-const configStub = Ember.Service.extend({
-  messages: {
+const configStub = Service.extend({
+  messages: { // eslint-disable-line ember/avoid-leaking-state-in-components
     successfulUpdateEmail: 'You have successfully updated your email!',
-    unsuccessfulUpdateEmail: 'We were unable to update your email.',
+    unsuccessfulUpdateEmail: 'We were unable to update your email.'
   }
 });
 
-const reauthenticateStub = Ember.Service.extend({
+const reauthenticateStub = Service.extend({
   shouldReauthenticate: false
 });
 
-const notifyStub = Ember.Service.extend({
-  lastMessage: "",
-  alert(message){
-    this.set("lastMessage", message);
+const notifyStub = Service.extend({
+  lastMessage: '',
+  alert(message) {
+    set(this, 'lastMessage', message);
   },
-  success(message){
-    this.set("lastMessage", message);
+  success(message) {
+    set(this, 'lastMessage', message);
   }
 });
 
 moduleForComponent('update-email', 'Integration | Component | update email', {
   integration: true,
-  beforeEach: function(){
+  beforeEach() {
     this.register('service:session', sessionStub);
     this.register('service:firebaseApp', firebaseStub);
     this.inject.service('firebaseApp');
@@ -65,51 +74,50 @@ moduleForComponent('update-email', 'Integration | Component | update email', {
 
 test('it renders', function(assert) {
   this.render(hbs`{{#update-email}}{{/update-email}}`);
-  assert.ok(this.$().text().trim().substring(0, 12), "Update Email");
+  assert.ok(this.$().text().trim().substring(0, 12), 'Update Email');
 });
 
-
-test(('Correct submission, when reauthentication is needed, should trigger that'), function(assert){
-  this.set("firebaseApp.needReauth", true);
+test(('Correct submission, when reauthentication is needed, should trigger that'), function(assert) {
+  set(this, 'firebaseApp.needReauth', true);
 
   this.render(hbs`{{#update-email}}{{/update-email}}`);
 
-  this.$('input').first().val("new@example.com").trigger('change');
-  this.$('input').last().val("new@example.com").trigger('change');
+  this.$('input').first().val('new@example.com').trigger('change');
+  this.$('input').last().val('new@example.com').trigger('change');
   this.$('button').click();
 
-  assert.equal(this.get("notify.lastMessage"), 'We were unable to update your email.');
-  assert.ok(this.get("reauthenticate.shouldReauthenticate"));
+  assert.equal(get(this, 'notify.lastMessage'), 'We were unable to update your email.');
+  assert.ok(get(this, 'reauthenticate.shouldReauthenticate'));
 });
 
-test(('Correct submission'), function(assert){
+test(('Correct submission'), function(assert) {
   this.render(hbs`{{#update-email}}{{/update-email}}`);
 
-  this.$('input').first().val("new@example.com").trigger('change');
-  this.$('input').last().val("new@example.com").trigger('change');
+  this.$('input').first().val('new@example.com').trigger('change');
+  this.$('input').last().val('new@example.com').trigger('change');
   this.$('button').click();
 
-  assert.equal(this.get("notify.lastMessage"), 'You have successfully updated your email!');
+  assert.equal(get(this, 'notify.lastMessage'), 'You have successfully updated your email!');
 });
 
-test(('If a submission is invalid, it should not pass'), function(assert){
+test(('If a submission is invalid, it should not pass'), function(assert) {
   this.render(hbs`{{#update-email}}{{/update-email}}`);
 
-  this.$('input').first().val("notanemail").trigger('change');
-  this.$('input').last().val("notanemail").trigger('change');
-  this.$('button').click();
-
-  // With a password that doesn't pass validation, notify should never be called.
-  assert.equal(this.get("notify.lastMessage"), '');
-});
-
-test(("Password that don't match shouldn't run"), function(assert){
-  this.render(hbs`{{#update-email}}{{/update-email}}`);
-
-  this.$('input').first().val("new@example.com").trigger('change');
-  this.$('input').last().val("new@example.clam").trigger('change');
+  this.$('input').first().val('notanemail').trigger('change');
+  this.$('input').last().val('notanemail').trigger('change');
   this.$('button').click();
 
   // With a password that doesn't pass validation, notify should never be called.
-  assert.equal(this.get("notify.lastMessage"), '');
+  assert.equal(get(this, 'notify.lastMessage'), '');
+});
+
+test(('Password that don\'t match shouldn\'t run'), function(assert) {
+  this.render(hbs`{{#update-email}}{{/update-email}}`);
+
+  this.$('input').first().val('new@example.com').trigger('change');
+  this.$('input').last().val('new@example.clam').trigger('change');
+  this.$('button').click();
+
+  // With a password that doesn't pass validation, notify should never be called.
+  assert.equal(get(this, 'notify.lastMessage'), '');
 });

--- a/tests/integration/components/update-password-test.js
+++ b/tests/integration/components/update-password-test.js
@@ -2,55 +2,63 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 
-const sessionStub = Ember.Service.extend({
+const {
+  Service,
+  RSVP,
+  get,
+  set
+} = Ember;
+
+const sessionStub = Service.extend({
   isAuthenticated: true
 });
 
-const firebaseStub = Ember.Service.extend({
-  auth(){
-    let reauth = this.get('needReauth');
+const firebaseStub = Service.extend({
+  needReauth: false,
+
+  auth() {
+    let reauth = get(this, 'needReauth');
     return {
       currentUser: {
-        email: "example@test.com",
-        updatePassword(){
-          return new Ember.RSVP.Promise((resolve, reject) => {
-            if (reauth){
-              reject({code: 'auth/requires-recent-login'});
-            }else{
+        email: 'example@test.com',
+        updatePassword() {
+          return new RSVP.Promise((resolve, reject) => {
+            if (reauth) {
+              reject({ code: 'auth/requires-recent-login' });
+            } else {
               resolve();
             }
           });
-        },
+        }
       }
     };
-  },
-  needReauth: false
+  }
 });
 
-const configStub = Ember.Service.extend({
-  messages: {
+const configStub = Service.extend({
+  messages: { // eslint-disable-line ember/avoid-leaking-state-in-components
     successfulUpdatePassword: 'You have successfully updated your password!',
     unsuccessfulUpdatePassword: 'We were unable to update your password.'
   }
 });
 
-const reauthenticateStub = Ember.Service.extend({
+const reauthenticateStub = Service.extend({
   shouldReauthenticate: false
 });
 
-const notifyStub = Ember.Service.extend({
-  lastMessage: "",
-  alert(message){
-    this.set("lastMessage", message);
+const notifyStub = Service.extend({
+  lastMessage: '',
+  alert(message) {
+    set(this, 'lastMessage', message);
   },
-  success(message){
-    this.set("lastMessage", message);
+  success(message) {
+    set(this, 'lastMessage', message);
   }
 });
 
 moduleForComponent('update-password', 'Integration | Component | update password', {
   integration: true,
-  beforeEach: function(){
+  beforeEach() {
     this.register('service:session', sessionStub);
     this.register('service:firebaseApp', firebaseStub);
     this.inject.service('firebaseApp');
@@ -66,50 +74,50 @@ moduleForComponent('update-password', 'Integration | Component | update password
 test('it renders', function(assert) {
   this.render(hbs`{{#update-password}}{{/update-password}}`);
 
-  assert.ok(this.$().text().trim().substring(0, 15), "Change Password");
-  assert.equal(this.$('input').length, 2, "There should be two input fields");
+  assert.ok(this.$().text().trim().substring(0, 15), 'Change Password');
+  assert.equal(this.$('input').length, 2, 'There should be two input fields');
 });
 
-test(('Correct submission, when reauthentication is needed, should trigger that'), function(assert){
-  this.set("firebaseApp.needReauth", true);
+test(('Correct submission, when reauthentication is needed, should trigger that'), function(assert) {
+  set(this, 'firebaseApp.needReauth', true);
 
   this.render(hbs`{{#update-password}}{{/update-password}}`);
 
-  this.$('input').first().val("newpassword").trigger('change');
-  this.$('input').last().val("newpassword").trigger('change');
+  this.$('input').first().val('newpassword').trigger('change');
+  this.$('input').last().val('newpassword').trigger('change');
   this.$('button').click();
 
-  assert.ok(this.get("reauthenticate.shouldReauthenticate"));
+  assert.ok(get(this, 'reauthenticate.shouldReauthenticate'));
 });
 
-test(('Correct submission'), function(assert){
+test(('Correct submission'), function(assert) {
   this.render(hbs`{{#update-password}}{{/update-password}}`);
 
-  this.$('input').first().val("newpassword").trigger('change');
-  this.$('input').last().val("newpassword").trigger('change');
+  this.$('input').first().val('newpassword').trigger('change');
+  this.$('input').last().val('newpassword').trigger('change');
   this.$('button').click();
 
-  assert.equal(this.get("notify.lastMessage"), 'You have successfully updated your password!');
+  assert.equal(get(this, 'notify.lastMessage'), 'You have successfully updated your password!');
 });
 
-test(('If a submission is too short, it should not pass'), function(assert){
+test(('If a submission is too short, it should not pass'), function(assert) {
   this.render(hbs`{{#update-password}}{{/update-password}}`);
 
-  this.$('input').first().val("n").trigger('change');
-  this.$('input').last().val("n").trigger('change');
-  this.$('button').click();
-
-  // With a password that doesn't pass validation, notify should never be called.
-  assert.equal(this.get("notify.lastMessage"), '');
-});
-
-test(("Password that don't match shouldn't run"), function(assert){
-  this.render(hbs`{{#update-password}}{{/update-password}}`);
-
-  this.$('input').first().val("newpassword").trigger('change');
-  this.$('input').last().val("newpassword+").trigger('change');
+  this.$('input').first().val('n').trigger('change');
+  this.$('input').last().val('n').trigger('change');
   this.$('button').click();
 
   // With a password that doesn't pass validation, notify should never be called.
-  assert.equal(this.get("notify.lastMessage"), '');
+  assert.equal(get(this, 'notify.lastMessage'), '');
+});
+
+test(('Password that don\'t match shouldn\'t run'), function(assert) {
+  this.render(hbs`{{#update-password}}{{/update-password}}`);
+
+  this.$('input').first().val('newpassword').trigger('change');
+  this.$('input').last().val('newpassword+').trigger('change');
+  this.$('button').click();
+
+  // With a password that doesn't pass validation, notify should never be called.
+  assert.equal(get(this, 'notify.lastMessage'), '');
 });

--- a/tests/integration/components/verify-email-test.js
+++ b/tests/integration/components/verify-email-test.js
@@ -2,43 +2,51 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 
-const firebaseStub = Ember.Service.extend({
-  auth(){
-    let emailVerified = this.get('emailVerified');
-    let error = this.get('shouldError');
+const {
+  RSVP,
+  Service,
+  get,
+  set
+} = Ember;
+
+const firebaseStub = Service.extend({
+  emailVerified: false,
+  shouldError: false,
+
+  auth() {
+    let emailVerified = get(this, 'emailVerified');
+    let error = get(this, 'shouldError');
     return {
       currentUser: {
-        emailVerified: emailVerified,
-        email: "example@test.com",
-        sendEmailVerification(){
-          return new Ember.RSVP.Promise((resolve, reject) => {
-            if (error){
-              reject({code: 'ERROR'});
-            }else{
+        emailVerified,
+        email: 'example@test.com',
+        sendEmailVerification() {
+          return new RSVP.Promise((resolve, reject) => {
+            if (error) {
+              reject({ code: 'ERROR' });
+            } else {
               resolve();
             }
           });
         }
       }
     };
-  },
-  emailVerified: false,
-  shouldError: false
+  }
 });
 
-const notifyStub = Ember.Service.extend({
-  lastMessage: "",
-  alert(message){
-    this.set("lastMessage", message);
+const notifyStub = Service.extend({
+  lastMessage: '',
+  alert(message) {
+    set(this, 'lastMessage', message);
   },
-  info(message){
-    this.set("lastMessage", message);
+  info(message) {
+    set(this, 'lastMessage', message);
   }
 });
 
 moduleForComponent('verify-email', 'Integration | Component | verify email', {
   integration: true,
-  beforeEach: function(){
+  beforeEach() {
     this.register('service:firebaseApp', firebaseStub);
     this.inject.service('firebaseApp');
 
@@ -55,7 +63,7 @@ test('it renders when the user needs to verify e-mail', function(assert) {
 });
 
 test('it renders differently when the user does not need to verify e-mail', function(assert) {
-  this.set('firebaseApp.emailVerified', true);
+  set(this, 'firebaseApp.emailVerified', true);
   this.render(hbs`{{#verify-email}}{{/verify-email}}`);
 
   assert.equal(this.$().text().trim().substring(0, 23), 'Send Email Verification');
@@ -66,21 +74,21 @@ test('Sends a Verification Email', function(assert) {
   this.render(hbs`{{#verify-email}}{{/verify-email}}`);
   this.$('button').click();
 
-  assert.equal(this.get("notify.lastMessage"), 'Email verification was sent, please check your inbox');
+  assert.equal(get(this, 'notify.lastMessage'), 'Email verification was sent, please check your inbox');
 });
 
 test('Checks if the user has been verified before sending email', function(assert) {
   this.render(hbs`{{#verify-email}}{{/verify-email}}`);
-  this.set('firebaseApp.emailVerified', true);
+  set(this, 'firebaseApp.emailVerified', true);
   this.$('button').click();
 
-  assert.equal(this.get("notify.lastMessage"), 'Error: Your email is already verified');
+  assert.equal(get(this, 'notify.lastMessage'), 'Error: Your email is already verified');
 });
 
 test('Responds to errors', function(assert) {
   this.render(hbs`{{#verify-email}}{{/verify-email}}`);
-  this.set('firebaseApp.shouldError', true);
+  set(this, 'firebaseApp.shouldError', true);
   this.$('button').click();
 
-  assert.equal(this.get("notify.lastMessage"), 'Error: ERROR');
+  assert.equal(get(this, 'notify.lastMessage'), 'Error: ERROR');
 });


### PR DESCRIPTION
This pull request is the culmination of fixing all eslint rules on the addon, making the account menu print HTML instead of text (using `{{{link}}}`), and making high security pages (change email, change password, and delete account) ask for the user's password instead of using the reauthenticate addon. This should make it closer to a typical account flow and keep the UI simpler.